### PR TITLE
feat: configure Material UI ThemeProvider with custom theme

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,12 +1,14 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
+import React from 'react'
+import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
-import '@fontsource/roboto'
+import { ThemeProvider } from '@mui/material/styles'
+import { theme } from './styles/theme'
+import '@fontsource/roboto' 
 
-
-createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <ThemeProvider theme={theme}>
+      <App />
+    </ThemeProvider>
+  </React.StrictMode>
 )

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,0 +1,15 @@
+import { createTheme } from '@mui/material/styles'
+
+export const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#1976d2',
+    },
+    secondary: {
+      main: '#dc004e',
+    },
+  },
+  typography: {
+    fontFamily: 'Roboto, sans-serif',
+  },
+})


### PR DESCRIPTION
- Created theme.js with primary/secondary palette and typography settings
- Wrapped app with ThemeProvider in main.jsx
- Imported Roboto font via @fontsource/roboto